### PR TITLE
Fixing a problem with culture

### DIFF
--- a/NYCJobsWeb/Controllers/HomeController.cs
+++ b/NYCJobsWeb/Controllers/HomeController.cs
@@ -3,6 +3,7 @@ using NYCJobsWeb.Models;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Globalization;
 using System.Linq;
 using System.Web;
 using System.Web.Mvc;
@@ -43,8 +44,8 @@ namespace NYCJobsWeb.Controllers
                 foreach (var result in zipReponse.Results)
                 {
                     var doc = (dynamic)result.Document;
-                    maxDistanceLat = Convert.ToString(doc["geo_location"].Latitude);
-                    maxDistanceLon = Convert.ToString(doc["geo_location"].Longitude);
+                    maxDistanceLat = Convert.ToString(doc["geo_location"].Latitude, CultureInfo.InvariantCulture);
+                    maxDistanceLon = Convert.ToString(doc["geo_location"].Longitude, CultureInfo.InvariantCulture);
                 }
             }
 

--- a/NYCJobsWeb/JobsSearch.cs
+++ b/NYCJobsWeb/JobsSearch.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.Search.Models;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Globalization;
 using System.Linq;
 using System.Web;
 
@@ -67,7 +68,7 @@ namespace NYCJobsWeb
                     sp.ScoringProfile = "jobsScoringFeatured";      // Use a scoring profile
                     sp.ScoringParameters = new List<ScoringParameter>();
                     sp.ScoringParameters.Add(new ScoringParameter("featuredParam", "featured"));
-                    sp.ScoringParameters.Add(new ScoringParameter("mapCenterParam", lon + "," + lat));
+                    sp.ScoringParameters.Add(new ScoringParameter("mapCenterParam", lon.ToString(CultureInfo.InvariantCulture) + "," + lat.ToString(CultureInfo.InvariantCulture)));
                 }
                 else if (sortType == "salaryDesc")
                     sp.OrderBy = new List<String>() { "salary_range_from desc" };


### PR DESCRIPTION
In some cultures the numbers with floating point use ',' and not '.'-char for separating. Because of it Azure Search throws an Exception. 
I added on two places a CultureInfo.InvariantCulture to fix this problem.
